### PR TITLE
Integrate Codecov for test coverage reporting

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,5 +27,12 @@ jobs:
     - name: Run tests
       run: |
         cd $GITHUB_WORKSPACE
-        export PYTHONPATH=$PYTHONPATH:./backend
-        pytest backend/tests/
+        export PYTHONPATH=$GITHUB_WORKSPACE:$GITHUB_WORKSPACE/backend
+        pytest --cov=./backend --cov-report=xml:coverage.xml backend/tests/
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        fail_ci_if_error: true

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ pytest-asyncio
 httpx
 mongomock-motor
 pytest-env
+pytest-cov


### PR DESCRIPTION
This commit introduces Codecov integration into the GitHub Actions workflow.

Key changes:
- Added `pytest-cov` to project dependencies.
- Modified the `run-tests.yml` workflow:
    - Adjusted `PYTHONPATH` for correct coverage path mapping.
    - Updated the `pytest` command to generate an XML coverage report (`coverage.xml`).
    - Added a new step to upload the `coverage.xml` report to Codecov using `codecov/codecov-action@v4`.

This will enable tracking of test coverage over time and provide insights into code quality via Codecov.