### PR TITLE
Add mobile skeleton loading for Home Screen groups

### DIFF
--- a/.Jules/changelog.md
+++ b/.Jules/changelog.md
@@ -7,6 +7,13 @@
 ## [Unreleased]
 
 ### Added
+- **Mobile Skeleton Loading:** Implemented skeleton loading for the HomeScreen group list.
+  - **Features:**
+    - Created reusable `Skeleton` component with pulsing animation.
+    - Replaced `ActivityIndicator` with `GroupListSkeleton` in `HomeScreen`.
+    - Improved perceived performance and reduced layout shift.
+  - **Technical:** Created `mobile/components/ui/Skeleton.js` and `mobile/components/skeletons/GroupListSkeleton.js`.
+
 - **Password Strength Meter:** Added a visual password strength indicator to the signup form.
   - **Features:**
     - Real-time strength calculation (Length, Uppercase, Lowercase, Number, Symbol).

--- a/.Jules/todo.md
+++ b/.Jules/todo.md
@@ -57,7 +57,8 @@
   - Impact: Native feel, users can easily refresh data
   - Size: ~150 lines
 
-- [ ] **[ux]** Complete skeleton loading for HomeScreen groups
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
+  - Completed: 2026-02-09
   - File: `mobile/screens/HomeScreen.js`
   - Context: Replace ActivityIndicator with skeleton group cards
   - Impact: Better loading experience, less jarring

--- a/mobile/components/skeletons/GroupListSkeleton.js
+++ b/mobile/components/skeletons/GroupListSkeleton.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Card } from 'react-native-paper';
+import Skeleton from '../ui/Skeleton';
+
+const GroupListSkeleton = () => {
+  return (
+    <View
+      style={styles.container}
+      accessible={true}
+      accessibilityLabel="Loading groups"
+      accessibilityRole="progressbar"
+    >
+      {[...Array(5)].map((_, index) => (
+        <Card key={index} style={styles.card}>
+          <Card.Title
+            title={<Skeleton width={120} height={20} />}
+            left={(props) => (
+              <Skeleton
+                width={props.size}
+                height={props.size}
+                borderRadius={props.size / 2}
+              />
+            )}
+          />
+          <Card.Content>
+            <Skeleton width={200} height={16} style={styles.subtitle} />
+          </Card.Content>
+        </Card>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+  subtitle: {
+    marginTop: 4,
+  },
+});
+
+export default GroupListSkeleton;

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius = 4, style }) => {
+  const theme = useTheme();
+  const opacity = useRef(new Animated.Value(0.5)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.5,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+      ])
+    ).start();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={[
+        {
+          width,
+          height,
+          borderRadius,
+          backgroundColor: theme.colors.surfaceVariant,
+          opacity,
+        },
+        style,
+      ]}
+      accessibilityRole="progressbar"
+      accessibilityLabel="Loading..."
+    />
+  );
+};
+
+export default Skeleton;

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -13,6 +13,7 @@ import {
 import HapticButton from '../components/ui/HapticButton';
 import HapticCard from '../components/ui/HapticCard';
 import { HapticAppbarAction } from '../components/ui/HapticAppbar';
+import GroupListSkeleton from '../components/skeletons/GroupListSkeleton';
 import * as Haptics from "expo-haptics";
 import { createGroup, getGroups, getOptimizedSettlements } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
@@ -257,9 +258,7 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" />
-        </View>
+        <GroupListSkeleton />
       ) : (
         <FlatList
           data={groups}
@@ -288,11 +287,6 @@ const HomeScreen = ({ navigation }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  loaderContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
   },
   list: {
     padding: 16,


### PR DESCRIPTION
Implemented a skeleton loading state for the mobile Home Screen to improve the perceived performance and user experience.

**Features:**
- Created a reusable `Skeleton` primitive component in `mobile/components/ui/Skeleton.js` that supports pulsing animations and theme adaptation.
- Created `GroupListSkeleton` in `mobile/components/skeletons/GroupListSkeleton.js` that mimics the layout of the group list cards.
- Replaced the generic `ActivityIndicator` in `mobile/screens/HomeScreen.js` with the new skeleton loading state.
- Ensured accessibility by adding proper roles and labels to the skeleton container.

**Changes:**
- `mobile/components/ui/Skeleton.js`: New component.
- `mobile/components/skeletons/GroupListSkeleton.js`: New component.
- `mobile/screens/HomeScreen.js`: Replaced loader with skeleton, removed unused styles.
- `.Jules/todo.md`: Marked task as complete.
- `.Jules/changelog.md`: Added entry for the new feature.

---
*PR created automatically by Jules for task [3504540643638496533](https://jules.google.com/task/3504540643638496533) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented skeleton loading placeholders with pulsing animation for group lists on the home screen. This replaces the previous loading spinner, enhancing perceived performance and minimizing visual layout shifts during data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->