### PR TITLE
[jules] ux: Complete skeleton loading for HomeScreen groups

### DIFF
--- a/.Jules/changelog.md
+++ b/.Jules/changelog.md
@@ -7,6 +7,14 @@
 ## [Unreleased]
 
 ### Added
+- **Mobile Skeleton Loading:** Implemented a skeleton loading state for the Home screen group list.
+  - **Features:**
+    - Created reusable `Skeleton` component with pulsing animation.
+    - Created `GroupCardSkeleton` mimicking the exact layout of group cards.
+    - Replaced `ActivityIndicator` with a list of skeletons for a smoother loading experience.
+    - Maintained theme consistency using `surfaceVariant` color.
+  - **Technical:** Created `mobile/components/ui/Skeleton.js`, `mobile/components/skeletons/GroupCardSkeleton.js`. Updated `mobile/screens/HomeScreen.js`.
+
 - **Password Strength Meter:** Added a visual password strength indicator to the signup form.
   - **Features:**
     - Real-time strength calculation (Length, Uppercase, Lowercase, Number, Symbol).

--- a/.Jules/todo.md
+++ b/.Jules/todo.md
@@ -57,12 +57,12 @@
   - Impact: Native feel, users can easily refresh data
   - Size: ~150 lines
 
-- [ ] **[ux]** Complete skeleton loading for HomeScreen groups
-  - File: `mobile/screens/HomeScreen.js`
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
+  - Completed: 2026-02-12
+  - Files: `mobile/components/ui/Skeleton.js`, `mobile/components/skeletons/GroupCardSkeleton.js`, `mobile/screens/HomeScreen.js`
   - Context: Replace ActivityIndicator with skeleton group cards
   - Impact: Better loading experience, less jarring
-  - Size: ~40 lines
-  - Added: 2026-01-01
+  - Size: ~80 lines
 
 - [x] **[a11y]** Complete accessibility labels for all screens
   - Completed: 2026-01-29

--- a/mobile/components/skeletons/GroupCardSkeleton.js
+++ b/mobile/components/skeletons/GroupCardSkeleton.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Card } from 'react-native-paper';
+import Skeleton from '../ui/Skeleton';
+
+const GroupCardSkeleton = () => {
+  return (
+    <Card style={styles.card}>
+      <Card.Title
+        title={<Skeleton width={120} height={20} />}
+        left={() => <Skeleton width={40} height={40} borderRadius={20} />}
+      />
+      <Card.Content>
+        <Skeleton width={200} height={16} style={styles.subtitle} />
+      </Card.Content>
+    </Card>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+  },
+  subtitle: {
+    marginTop: 4,
+  },
+});
+
+export default GroupCardSkeleton;

--- a/mobile/components/skeletons/GroupCardSkeleton.js
+++ b/mobile/components/skeletons/GroupCardSkeleton.js
@@ -3,15 +3,19 @@ import { StyleSheet } from 'react-native';
 import { Card } from 'react-native-paper';
 import Skeleton from '../ui/Skeleton';
 
-const GroupCardSkeleton = () => {
+const GroupCardSkeleton = ({ index = 0 }) => {
+  // Deterministic random-looking widths based on index
+  const titleWidth = 100 + ((index * 37) % 60); // 100 - 159
+  const subtitleWidth = 140 + ((index * 53) % 90); // 140 - 229
+
   return (
     <Card style={styles.card}>
       <Card.Title
-        title={<Skeleton width={120} height={20} />}
+        title={<Skeleton width={titleWidth} height={20} />}
         left={() => <Skeleton width={40} height={40} borderRadius={20} />}
       />
       <Card.Content>
-        <Skeleton width={200} height={16} style={styles.subtitle} />
+        <Skeleton width={subtitleWidth} height={16} style={styles.subtitle} />
       </Card.Content>
     </Card>
   );

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius = 4, style }) => {
+  const theme = useTheme();
+  const opacity = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 0.7,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.3,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={[
+        {
+          width,
+          height,
+          borderRadius,
+          opacity,
+          backgroundColor: theme.colors.surfaceVariant,
+        },
+        style,
+      ]}
+    />
+  );
+};
+
+export default Skeleton;

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
+import { Animated, StyleSheet } from 'react-native';
 import { useTheme } from 'react-native-paper';
 
 const Skeleton = ({ width, height, borderRadius = 4, style }) => {

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from "react";
-import { Alert, FlatList, RefreshControl, StyleSheet, View } from "react-native";
+import { Alert, FlatList, RefreshControl, ScrollView, StyleSheet, View } from "react-native";
 import {
   Appbar,
   Avatar,
@@ -257,11 +257,11 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.list} accessible={true} accessibilityLabel="Loading groups">
+        <ScrollView style={styles.list} accessible={true} accessibilityLabel="Loading groups">
           {[1, 2, 3, 4, 5, 6].map((i) => (
-            <GroupCardSkeleton key={i} />
+            <GroupCardSkeleton key={i} index={i} />
           ))}
-        </View>
+        </ScrollView>
       ) : (
         <FlatList
           data={groups}

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import { Alert, FlatList, RefreshControl, StyleSheet, View } from "react-native";
 import {
-  ActivityIndicator,
   Appbar,
   Avatar,
   Modal,
@@ -13,6 +12,7 @@ import {
 import HapticButton from '../components/ui/HapticButton';
 import HapticCard from '../components/ui/HapticCard';
 import { HapticAppbarAction } from '../components/ui/HapticAppbar';
+import GroupCardSkeleton from '../components/skeletons/GroupCardSkeleton';
 import * as Haptics from "expo-haptics";
 import { createGroup, getGroups, getOptimizedSettlements } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
@@ -257,8 +257,10 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" />
+        <View style={styles.list} accessible={true} accessibilityLabel="Loading groups">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <GroupCardSkeleton key={i} />
+          ))}
         </View>
       ) : (
         <FlatList
@@ -288,11 +290,6 @@ const HomeScreen = ({ navigation }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  loaderContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
   },
   list: {
     padding: 16,


### PR DESCRIPTION
Implemented a skeleton loading state for the Home screen group list on mobile. Created a reusable `Skeleton` component with pulsing animation and a `GroupCardSkeleton` that mimics the layout of the group cards. Replaced the `ActivityIndicator` with a list of skeletons to provide a smoother loading experience.

---
*PR created automatically by Jules for task [11200287480580375099](https://jules.google.com/task/11200287480580375099) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a skeleton loading state for the Home screen group list with animated, pulsing placeholder cards to improve perceived performance.
  * Introduced a reusable Skeleton component and a GroupCard-style skeleton so placeholders match real content layout.
  * Replaced the previous centered spinner with a scrollable list of accessible skeleton cards labeled for screen readers, reducing layout jank during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->