### PR TITLE
[UX] Mobile Home Screen Skeleton Loading

### DIFF
--- a/.Jules/changelog.md
+++ b/.Jules/changelog.md
@@ -7,6 +7,13 @@
 ## [Unreleased]
 
 ### Added
+- **Mobile Skeleton Loading:** Implemented skeleton loading state for HomeScreen.
+  - **Features:**
+    - Created reusable `Skeleton` component with pulsing animation and theme support.
+    - Created `GroupListSkeleton` to mimic the layout of group cards.
+    - Replaced `ActivityIndicator` in `HomeScreen` with the skeleton loader.
+  - **Technical:** Created `mobile/components/ui/Skeleton.js` and `mobile/components/skeletons/GroupListSkeleton.js`.
+
 - **Password Strength Meter:** Added a visual password strength indicator to the signup form.
   - **Features:**
     - Real-time strength calculation (Length, Uppercase, Lowercase, Number, Symbol).

--- a/.Jules/knowledge.md
+++ b/.Jules/knowledge.md
@@ -306,6 +306,17 @@ Commonly used components:
 
 Most screens use `<View style={{ flex: 1 }}>` - consider wrapping in `SafeAreaView` for notched devices.
 
+### Skeleton Loading Pattern
+
+**Date:** 2026-02-09
+**Context:** Improving mobile loading states
+
+To create a skeleton loader that matches the content layout:
+
+1.  **Base Component:** Create a `Skeleton` component using `Animated` for pulsing opacity and `useTheme` for colors (`surfaceVariant`).
+2.  **Layout Component:** Create a composite skeleton (e.g., `GroupListSkeleton`) that uses `Card` (or other containers) to mimic the exact structure of the loaded content (including padding/margins).
+3.  **Integration:** Replace `ActivityIndicator` with the skeleton component in the `isLoading` state.
+
 ### Accessibility Patterns
 
 **Date:** 2026-01-29

--- a/.Jules/todo.md
+++ b/.Jules/todo.md
@@ -57,12 +57,12 @@
   - Impact: Native feel, users can easily refresh data
   - Size: ~150 lines
 
-- [ ] **[ux]** Complete skeleton loading for HomeScreen groups
-  - File: `mobile/screens/HomeScreen.js`
-  - Context: Replace ActivityIndicator with skeleton group cards
-  - Impact: Better loading experience, less jarring
-  - Size: ~40 lines
-  - Added: 2026-01-01
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
+  - Completed: 2026-02-09
+  - Files modified: `mobile/screens/HomeScreen.js`, `mobile/components/ui/Skeleton.js`, `mobile/components/skeletons/GroupListSkeleton.js`
+  - Context: Replaced ActivityIndicator with skeleton group cards
+  - Impact: Better loading experience, less jarring, matches list layout
+  - Size: ~80 lines
 
 - [x] **[a11y]** Complete accessibility labels for all screens
   - Completed: 2026-01-29

--- a/mobile/components/skeletons/GroupListSkeleton.js
+++ b/mobile/components/skeletons/GroupListSkeleton.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Card } from 'react-native-paper';
+import Skeleton from '../ui/Skeleton';
+
+const GroupListSkeleton = () => {
+  // Render 5 items to fill the screen
+  const items = Array.from({ length: 5 }, (_, i) => i);
+
+  return (
+    <View style={styles.container} accessible={true} accessibilityLabel="Loading groups">
+      {items.map((key) => (
+        <Card key={key} style={styles.card}>
+          <Card.Title
+            title={<Skeleton width={150} height={20} />}
+            left={(props) => (
+              <Skeleton width={40} height={40} borderRadius={20} />
+            )}
+          />
+          <Card.Content>
+            <Skeleton width={200} height={16} style={{ marginTop: 4 }} />
+          </Card.Content>
+        </Card>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+});
+
+export default GroupListSkeleton;

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, View, StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius = 4, style }) => {
+  const theme = useTheme();
+  const opacity = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.3,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    animation.start();
+
+    return () => animation.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={[
+        {
+          opacity,
+          width,
+          height,
+          borderRadius,
+          backgroundColor: theme.colors.surfaceVariant,
+        },
+        style,
+      ]}
+      accessibilityRole="progressbar"
+      accessibilityLabel="Loading..."
+    />
+  );
+};
+
+export default Skeleton;

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import { Alert, FlatList, RefreshControl, StyleSheet, View } from "react-native";
 import {
-  ActivityIndicator,
   Appbar,
   Avatar,
   Modal,
@@ -15,6 +14,7 @@ import HapticCard from '../components/ui/HapticCard';
 import { HapticAppbarAction } from '../components/ui/HapticAppbar';
 import * as Haptics from "expo-haptics";
 import { createGroup, getGroups, getOptimizedSettlements } from "../api/groups";
+import GroupListSkeleton from '../components/skeletons/GroupListSkeleton';
 import { AuthContext } from "../context/AuthContext";
 import { formatCurrency, getCurrencySymbol } from "../utils/currency";
 
@@ -257,9 +257,7 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" />
-        </View>
+        <GroupListSkeleton />
       ) : (
         <FlatList
           data={groups}
@@ -288,11 +286,6 @@ const HomeScreen = ({ navigation }) => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  loaderContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
   },
   list: {
     padding: 16,


### PR DESCRIPTION
Implemented a skeleton loading state for the mobile Home Screen to improve perceived performance and visual consistency. Replaced the generic `ActivityIndicator` with a `GroupListSkeleton` that mimics the layout of the group cards, including avatars and status text. Created a reusable base `Skeleton` component using `Animated` for pulsing effects and `react-native-paper` theming.

---
*PR created automatically by Jules for task [1918836578316525257](https://jules.google.com/task/1918836578316525257) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced animated skeleton placeholder cards during group content loading that mirror the structure of the actual list, with pulsing animation and theme-aware styling.

* **Documentation**
  * Added skeleton loading patterns and implementation guidelines to the mobile development knowledge base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->