### PR TITLE
[jules] ux: Add skeleton loading to mobile HomeScreen

### DIFF
--- a/.Jules/changelog.md
+++ b/.Jules/changelog.md
@@ -7,6 +7,14 @@
 ## [Unreleased]
 
 ### Added
+- **Mobile Skeleton Loading:** Implemented pulsing skeleton loading state for the Home Screen group list.
+  - **Features:**
+    - Created reusable `Skeleton` component with pulsing animation using `Animated` and `useTheme`.
+    - Created `GroupListSkeleton` to mimic the layout of group cards (Avatar + Title + Subtitle).
+    - Integrated into `HomeScreen.js` to replace the generic `ActivityIndicator`.
+    - Matches layout metrics to prevent content jumping.
+  - **Technical:** Created `mobile/components/ui/Skeleton.js` and `mobile/components/skeletons/GroupListSkeleton.js`.
+
 - **Password Strength Meter:** Added a visual password strength indicator to the signup form.
   - **Features:**
     - Real-time strength calculation (Length, Uppercase, Lowercase, Number, Symbol).

--- a/.Jules/todo.md
+++ b/.Jules/todo.md
@@ -57,7 +57,8 @@
   - Impact: Native feel, users can easily refresh data
   - Size: ~150 lines
 
-- [ ] **[ux]** Complete skeleton loading for HomeScreen groups
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
+  - Completed: 2026-02-18
   - File: `mobile/screens/HomeScreen.js`
   - Context: Replace ActivityIndicator with skeleton group cards
   - Impact: Better loading experience, less jarring

--- a/mobile/components/skeletons/GroupListSkeleton.js
+++ b/mobile/components/skeletons/GroupListSkeleton.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Card } from 'react-native-paper';
+import Skeleton from '../ui/Skeleton';
+
+const GroupListSkeleton = () => {
+  // Create an array of 5 items to mimic a list
+  const items = Array.from({ length: 5 }, (_, i) => i);
+
+  return (
+    <View style={styles.container}>
+      {items.map((key) => (
+        <Card key={key} style={styles.card}>
+          <Card.Title
+            title={<Skeleton width={150} height={20} />}
+            left={() => <Skeleton width={40} height={40} borderRadius={20} />}
+          />
+          <Card.Content>
+            <Skeleton width="100%" height={16} style={styles.subtitle} />
+          </Card.Content>
+        </Card>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+  subtitle: {
+    marginTop: 4,
+  },
+});
+
+export default GroupListSkeleton;

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, View } from 'react-native';
+import { Surface, useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius = 4, style }) => {
+  const theme = useTheme();
+  const opacity = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 0.7,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.3,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+
+    loop.start();
+
+    return () => loop.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={[
+        {
+          opacity,
+          width,
+          height,
+          borderRadius,
+          backgroundColor: theme.colors.surfaceVariant,
+          overflow: 'hidden',
+        },
+        style,
+      ]}
+    />
+  );
+};
+
+export default Skeleton;

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -13,6 +13,7 @@ import {
 import HapticButton from '../components/ui/HapticButton';
 import HapticCard from '../components/ui/HapticCard';
 import { HapticAppbarAction } from '../components/ui/HapticAppbar';
+import GroupListSkeleton from '../components/skeletons/GroupListSkeleton';
 import * as Haptics from "expo-haptics";
 import { createGroup, getGroups, getOptimizedSettlements } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
@@ -257,9 +258,7 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" />
-        </View>
+        <GroupListSkeleton />
       ) : (
         <FlatList
           data={groups}


### PR DESCRIPTION
Implemented a complete skeleton loading system for the mobile HomeScreen to improve perceived performance.

- Created a reusable `Skeleton` component (`mobile/components/ui/Skeleton.js`) using `Animated` for a pulsing opacity effect, with support for `react-native-paper` themes.
- Created `GroupListSkeleton` (`mobile/components/skeletons/GroupListSkeleton.js`) that mimics the exact layout of the group list items (Avatar + Title + Subtitle).
- Replaced the generic `ActivityIndicator` in `HomeScreen.js` with `GroupListSkeleton`.
- Updated `.Jules/todo.md` and `.Jules/changelog.md` to track this enhancement.

---
*PR created automatically by Jules for task [8108891635608244981](https://jules.google.com/task/8108891635608244981) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated skeleton loading state to the Home Screen group list, featuring pulsing placeholder cards that replace the loading spinner and prevent layout shifts when content loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->