### PR TITLE
[jules] enhance: Add skeleton loading to mobile Home screen

### DIFF
--- a/.Jules/changelog.md
+++ b/.Jules/changelog.md
@@ -123,3 +123,8 @@
 - `.jules/todo.md`
 - `.jules/knowledge.md`
 - `.jules/changelog.md`
+
+### 2026-03-08
+- Added generic `Skeleton` component and `GroupListSkeleton` component to mobile app
+- Replaced basic ActivityIndicator loading screen with `GroupListSkeleton` on mobile `HomeScreen`
+- Refactored `FriendsScreen` inline skeleton logic to use the new generic `Skeleton` component

--- a/.Jules/knowledge.md
+++ b/.Jules/knowledge.md
@@ -756,3 +756,8 @@ _Document errors and their solutions here as you encounter them._
 - react-native-paper: UI components
 - axios: API calls (via api/client.js)
 - expo: Platform SDK
+
+### Development Workflows
+- The mobile project is configured with `react-native-web`. You can test it in a browser using `npx expo start --web`.
+- Use `AsyncStorage` values (`auth_token`, `refresh_token`, `user_data`) directly into Playwright's `window.localStorage` to bypass login flows for Playwright testing via react-native-web.
+- When creating files in new subdirectories inside `/mobile/`, use `mkdir -p` before the write operation to ensure the path exists.

--- a/.Jules/todo.md
+++ b/.Jules/todo.md
@@ -57,8 +57,9 @@
   - Impact: Native feel, users can easily refresh data
   - Size: ~150 lines
 
-- [ ] **[ux]** Complete skeleton loading for HomeScreen groups
-  - File: `mobile/screens/HomeScreen.js`
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
+  - Completed: 2026-03-08
+  - File: `mobile/screens/HomeScreen.js`, `mobile/components/ui/Skeleton.js`, `mobile/components/skeletons/GroupListSkeleton.js`
   - Context: Replace ActivityIndicator with skeleton group cards
   - Impact: Better loading experience, less jarring
   - Size: ~40 lines
@@ -168,3 +169,7 @@
   - Completed: 2026-02-08
   - Files modified: `web/components/ui/PasswordStrength.tsx`, `web/pages/Auth.tsx`
   - Impact: Provides visual feedback on password complexity during signup
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
+  - Completed: 2026-03-08
+  - Files modified: `mobile/screens/HomeScreen.js`, `mobile/screens/FriendsScreen.js`, `mobile/components/ui/Skeleton.js`, `mobile/components/skeletons/GroupListSkeleton.js`
+  - Impact: Better loading experience across the mobile app via generic skeleton components.

--- a/mobile/components/skeletons/GroupListSkeleton.js
+++ b/mobile/components/skeletons/GroupListSkeleton.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Card } from 'react-native-paper';
+import Skeleton from '../ui/Skeleton';
+
+const GroupListSkeleton = ({ count = 5 }) => {
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="progressbar"
+      accessibilityLabel="Loading groups list"
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <Card key={index} style={styles.card}>
+          <Card.Title
+            title={<Skeleton width={120} height={20} borderRadius={4} />}
+            left={(props) => (
+              <Skeleton
+                width={props.size || 40}
+                height={props.size || 40}
+                borderRadius={(props.size || 40) / 2}
+                style={{ marginLeft: -8 }}
+              />
+            )}
+          />
+          <Card.Content>
+            <Skeleton width={180} height={16} borderRadius={4} style={{ marginTop: 4 }} />
+          </Card.Content>
+        </Card>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+});
+
+export default GroupListSkeleton;

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius = 4, style }) => {
+  const theme = useTheme();
+  const opacityAnim = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacityAnim, {
+          toValue: 1,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacityAnim, {
+          toValue: 0.3,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [opacityAnim]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.skeleton,
+        {
+          width,
+          height,
+          borderRadius,
+          backgroundColor: theme.colors.surfaceVariant,
+          opacity: opacityAnim,
+        },
+        style,
+      ]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  skeleton: {
+    overflow: 'hidden',
+  },
+});
+
+export default Skeleton;

--- a/mobile/screens/FriendsScreen.js
+++ b/mobile/screens/FriendsScreen.js
@@ -1,6 +1,6 @@
 import { useIsFocused } from "@react-navigation/native";
-import { useContext, useEffect, useRef, useState } from "react";
-import { Alert, Animated, FlatList, RefreshControl, StyleSheet, View } from "react-native";
+import { useContext, useEffect, useState } from "react";
+import { Alert, FlatList, RefreshControl, StyleSheet, View } from "react-native";
 import {
   Appbar,
   Avatar,
@@ -15,6 +15,7 @@ import { triggerPullRefreshHaptic } from '../components/ui/hapticUtils';
 import { getFriendsBalance, getGroups } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
 import { formatCurrency } from "../utils/currency";
+import Skeleton from "../components/ui/Skeleton";
 
 const FriendsScreen = () => {
   const { token, user } = useContext(AuthContext);
@@ -167,42 +168,12 @@ const FriendsScreen = () => {
     );
   };
 
-  // Shimmer skeleton components
-  const opacityAnim = useRef(new Animated.Value(0.3)).current;
-  useEffect(() => {
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacityAnim, {
-          toValue: 1,
-          duration: 700,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacityAnim, {
-          toValue: 0.3,
-          duration: 700,
-          useNativeDriver: true,
-        }),
-      ])
-    );
-    loop.start();
-    return () => loop.stop();
-  }, [opacityAnim]);
-
   const SkeletonRow = () => (
     <View style={styles.skeletonRow}>
-      <Animated.View
-        style={[styles.skeletonAvatar, { opacity: opacityAnim }]}
-      />
+      <Skeleton width={48} height={48} borderRadius={24} />
       <View style={{ flex: 1, marginLeft: 12 }}>
-        <Animated.View
-          style={[styles.skeletonLine, { width: "60%", opacity: opacityAnim }]}
-        />
-        <Animated.View
-          style={[
-            styles.skeletonLineSmall,
-            { width: "40%", opacity: opacityAnim },
-          ]}
-        />
+        <Skeleton width="60%" height={14} borderRadius={6} style={{ marginBottom: 6 }} />
+        <Skeleton width="40%" height={12} borderRadius={6} />
       </View>
     </View>
   );
@@ -314,23 +285,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     marginBottom: 14,
-  },
-  skeletonAvatar: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-    backgroundColor: "#e0e0e0",
-  },
-  skeletonLine: {
-    height: 14,
-    backgroundColor: "#e0e0e0",
-    borderRadius: 6,
-    marginBottom: 6,
-  },
-  skeletonLineSmall: {
-    height: 12,
-    backgroundColor: "#e0e0e0",
-    borderRadius: 6,
   },
 });
 

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import { Alert, FlatList, RefreshControl, StyleSheet, View } from "react-native";
 import {
-  ActivityIndicator,
   Appbar,
   Avatar,
   Modal,
@@ -17,6 +16,7 @@ import * as Haptics from "expo-haptics";
 import { createGroup, getGroups, getOptimizedSettlements } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
 import { formatCurrency, getCurrencySymbol } from "../utils/currency";
+import GroupListSkeleton from "../components/skeletons/GroupListSkeleton";
 
 const HomeScreen = ({ navigation }) => {
   const { token, logout, user } = useContext(AuthContext);
@@ -257,9 +257,7 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" />
-        </View>
+        <GroupListSkeleton count={5} />
       ) : (
         <FlatList
           data={groups}


### PR DESCRIPTION
## What does this change?
This change adds a comprehensive skeleton loading experience to the mobile app's `HomeScreen` to improve the perceived performance and provide a better UX. It also implements a generic `Skeleton` component and refactors existing uses of inline loading states to utilize it.

### Core Changes
1. Created `mobile/components/ui/Skeleton.js`, a highly reusable component for generic loading states that utilizes `Animated.loop` for smooth pulsing.
2. Created `mobile/components/skeletons/GroupListSkeleton.js` to specifically match the layout of the `HomeScreen` group cards.
3. Updated `mobile/screens/HomeScreen.js` to render the `GroupListSkeleton` rather than a standard spinning `ActivityIndicator` while data is loading.
4. Refactored `mobile/screens/FriendsScreen.js` to remove its messy, inline, and duplicated `Animated` skeleton logic and replace it with the new standard `Skeleton` component imports.
5. Added relevant tracking updates to the `todo.md`, `changelog.md` and `knowledge.md` files in the `.Jules` folder.

This satisfies the UX todo: "Complete skeleton loading for HomeScreen groups".

---
*PR created automatically by Jules for task [5893515721313771645](https://jules.google.com/task/5893515721313771645) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added animated skeleton placeholders to mobile screens during content loading, replacing spinner loaders with skeleton cards that preview the final layout.

* **Refactor**
  * Standardized loading UI patterns across mobile screens with consistent skeleton components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->