### PR TITLE
[jules] enhance: Add skeleton loading for HomeScreen groups

### DIFF
--- a/.Jules/changelog.md
+++ b/.Jules/changelog.md
@@ -7,6 +7,14 @@
 ## [Unreleased]
 
 ### Added
+- **Mobile Skeleton Loading:** Replaced basic ActivityIndicator with a sophisticated `GroupListSkeleton` in `HomeScreen`.
+  - **Features:**
+    - Created reusable animated `Skeleton` primitive.
+    - Created `GroupListSkeleton` mimicking actual `HapticCard` layout.
+    - Implemented subtle pulse animation matching theme variants.
+    - Fully accessible with appropriate `progressbar` roles and labels.
+  - **Technical:** Created `mobile/components/ui/Skeleton.js` and `mobile/components/skeletons/GroupListSkeleton.js`. Integrated into `mobile/screens/HomeScreen.js`.
+
 - **Password Strength Meter:** Added a visual password strength indicator to the signup form.
   - **Features:**
     - Real-time strength calculation (Length, Uppercase, Lowercase, Number, Symbol).

--- a/.Jules/todo.md
+++ b/.Jules/todo.md
@@ -57,12 +57,13 @@
   - Impact: Native feel, users can easily refresh data
   - Size: ~150 lines
 
-- [ ] **[ux]** Complete skeleton loading for HomeScreen groups
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
   - File: `mobile/screens/HomeScreen.js`
   - Context: Replace ActivityIndicator with skeleton group cards
   - Impact: Better loading experience, less jarring
   - Size: ~40 lines
   - Added: 2026-01-01
+  - Completed: 2026-03-18
 
 - [x] **[a11y]** Complete accessibility labels for all screens
   - Completed: 2026-01-29

--- a/mobile/components/skeletons/GroupListSkeleton.js
+++ b/mobile/components/skeletons/GroupListSkeleton.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { View, StyleSheet, FlatList } from 'react-native';
+import { Card } from 'react-native-paper';
+import Skeleton from '../ui/Skeleton';
+
+const GroupListSkeleton = () => {
+  const renderSkeletonItem = ({ item }) => (
+    <Card style={styles.card}>
+      <Card.Title
+        title={<Skeleton width={120} height={20} borderRadius={4} />}
+        left={(props) => (
+          <View style={[props.style, styles.avatarPlaceholder]}>
+            <Skeleton width={40} height={40} borderRadius={20} />
+          </View>
+        )}
+      />
+      <Card.Content>
+        <Skeleton width={180} height={16} borderRadius={4} style={styles.contentSkeleton} />
+      </Card.Content>
+    </Card>
+  );
+
+  // Render 5 placeholder items
+  const skeletonData = Array.from({ length: 5 }).map((_, i) => ({ id: `skeleton-${i}` }));
+
+  return (
+    <View
+      style={styles.container}
+      accessible={true}
+      accessibilityRole="progressbar"
+      accessibilityLabel="Loading groups"
+    >
+      <FlatList
+        data={skeletonData}
+        renderItem={renderSkeletonItem}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        scrollEnabled={false} // Disable scrolling for skeleton list
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  list: {
+    padding: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+  avatarPlaceholder: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  contentSkeleton: {
+    marginTop: 4,
+  },
+});
+
+export default GroupListSkeleton;

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, View, StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius = 4, style }) => {
+  const theme = useTheme();
+  const animatedValue = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(animatedValue, {
+          toValue: 0.7,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(animatedValue, {
+          toValue: 0.3,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    animation.start();
+
+    return () => animation.stop();
+  }, [animatedValue]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.skeleton,
+        {
+          width,
+          height,
+          borderRadius,
+          backgroundColor: theme.colors.surfaceVariant,
+          opacity: animatedValue,
+        },
+        style,
+      ]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  skeleton: {
+    overflow: 'hidden',
+  },
+});
+
+export default Skeleton;

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import { Alert, FlatList, RefreshControl, StyleSheet, View } from "react-native";
 import {
-  ActivityIndicator,
   Appbar,
   Avatar,
   Modal,
@@ -13,6 +12,7 @@ import {
 import HapticButton from '../components/ui/HapticButton';
 import HapticCard from '../components/ui/HapticCard';
 import { HapticAppbarAction } from '../components/ui/HapticAppbar';
+import GroupListSkeleton from '../components/skeletons/GroupListSkeleton';
 import * as Haptics from "expo-haptics";
 import { createGroup, getGroups, getOptimizedSettlements } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
@@ -257,9 +257,7 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" />
-        </View>
+        <GroupListSkeleton />
       ) : (
         <FlatList
           data={groups}


### PR DESCRIPTION
Replaced the basic `ActivityIndicator` on the `HomeScreen` with a sophisticated `GroupListSkeleton` that perfectly mimics the layout of the `HapticCard` elements. Created a reusable animated `Skeleton` primitive. This provides a much smoother, professional loading experience and reduces layout shift when groups load. Added corresponding updates to tracking files.

---
*PR created automatically by Jules for task [12872660234203792430](https://jules.google.com/task/12872660234203792430) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented animated skeleton loading for HomeScreen group lists, replacing the basic loading spinner with a visual preview of content structure.
  * Added subtle pulse animation for smoother visual feedback during data loading.
  * Improved accessibility with enhanced labels and roles for loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->