### PR TITLE
[jules] refactor: Use generic Skeleton component in FriendsScreen

### DIFF
--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius, style }) => {
+  const theme = useTheme();
+  const opacityAnim = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacityAnim, {
+          toValue: 1,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacityAnim, {
+          toValue: 0.3,
+          duration: 700,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    loop.start();
+
+    return () => loop.stop();
+  }, [opacityAnim]);
+
+  return (
+    <Animated.View
+      style={[
+        {
+          width,
+          height,
+          borderRadius: borderRadius || 0,
+          backgroundColor: theme.colors.surfaceVariant,
+          opacity: opacityAnim,
+        },
+        style,
+      ]}
+    />
+  );
+};
+
+export default Skeleton;

--- a/mobile/screens/FriendsScreen.js
+++ b/mobile/screens/FriendsScreen.js
@@ -1,6 +1,6 @@
 import { useIsFocused } from "@react-navigation/native";
-import { useContext, useEffect, useRef, useState } from "react";
-import { Alert, Animated, FlatList, RefreshControl, StyleSheet, View } from "react-native";
+import { useContext, useEffect, useState } from "react";
+import { Alert, FlatList, RefreshControl, StyleSheet, View } from "react-native";
 import {
   Appbar,
   Avatar,
@@ -12,6 +12,7 @@ import {
 import HapticIconButton from '../components/ui/HapticIconButton';
 import { HapticListAccordion } from '../components/ui/HapticList';
 import { triggerPullRefreshHaptic } from '../components/ui/hapticUtils';
+import Skeleton from '../components/ui/Skeleton';
 import { getFriendsBalance, getGroups } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
 import { formatCurrency } from "../utils/currency";
@@ -167,42 +168,12 @@ const FriendsScreen = () => {
     );
   };
 
-  // Shimmer skeleton components
-  const opacityAnim = useRef(new Animated.Value(0.3)).current;
-  useEffect(() => {
-    const loop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacityAnim, {
-          toValue: 1,
-          duration: 700,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacityAnim, {
-          toValue: 0.3,
-          duration: 700,
-          useNativeDriver: true,
-        }),
-      ])
-    );
-    loop.start();
-    return () => loop.stop();
-  }, [opacityAnim]);
-
   const SkeletonRow = () => (
     <View style={styles.skeletonRow}>
-      <Animated.View
-        style={[styles.skeletonAvatar, { opacity: opacityAnim }]}
-      />
+      <Skeleton width={48} height={48} borderRadius={24} />
       <View style={{ flex: 1, marginLeft: 12 }}>
-        <Animated.View
-          style={[styles.skeletonLine, { width: "60%", opacity: opacityAnim }]}
-        />
-        <Animated.View
-          style={[
-            styles.skeletonLineSmall,
-            { width: "40%", opacity: opacityAnim },
-          ]}
-        />
+        <Skeleton width="60%" height={14} borderRadius={6} style={{ marginBottom: 6 }} />
+        <Skeleton width="40%" height={12} borderRadius={6} />
       </View>
     </View>
   );
@@ -314,23 +285,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     marginBottom: 14,
-  },
-  skeletonAvatar: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
-    backgroundColor: "#e0e0e0",
-  },
-  skeletonLine: {
-    height: 14,
-    backgroundColor: "#e0e0e0",
-    borderRadius: 6,
-    marginBottom: 6,
-  },
-  skeletonLineSmall: {
-    height: 12,
-    backgroundColor: "#e0e0e0",
-    borderRadius: 6,
   },
 });
 


### PR DESCRIPTION
Extracted the inline skeleton animation logic from FriendsScreen into a highly reusable `Skeleton` primitive in `mobile/components/ui/`. Refactored `FriendsScreen` to import and utilize the new generic component to produce a consistent and visually identical loading state while supporting light and dark themes out-of-the-box.

---
*PR created automatically by Jules for task [6500990729041499595](https://jules.google.com/task/6500990729041499595) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable skeleton loading placeholder component for consistent loading state UI.

* **Refactor**
  * Updated the Friends screen to use the new skeleton component for loading placeholders, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->