### PR TITLE
[jules] enhance: Add skeleton loading state for HomeScreen groups

### DIFF
--- a/.Jules/changelog.md
+++ b/.Jules/changelog.md
@@ -7,6 +7,13 @@
 ## [Unreleased]
 
 ### Added
+- **Mobile Skeleton Loading States:** Replaced generic activity indicators with animated skeleton layouts on the HomeScreen.
+  - **Features:**
+    - Created reusable pulsing `Skeleton` UI primitive.
+    - Created `GroupListSkeleton` to match actual group card layout.
+    - Reduced layout shift during data fetching.
+    - Optimized accessibility for screen readers (`role="progressbar"`, container-level labels to minimize noise).
+  - **Technical:** Created `mobile/components/ui/Skeleton.js` and `mobile/components/skeletons/GroupListSkeleton.js`. Integrated into `mobile/screens/HomeScreen.js`.
 - **Password Strength Meter:** Added a visual password strength indicator to the signup form.
   - **Features:**
     - Real-time strength calculation (Length, Uppercase, Lowercase, Number, Symbol).

--- a/.Jules/todo.md
+++ b/.Jules/todo.md
@@ -57,7 +57,11 @@
   - Impact: Native feel, users can easily refresh data
   - Size: ~150 lines
 
-- [ ] **[ux]** Complete skeleton loading for HomeScreen groups
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
+  - Completed: 2026-04-04
+  - Files: `mobile/components/ui/Skeleton.js`, `mobile/components/skeletons/GroupListSkeleton.js`, `mobile/screens/HomeScreen.js`
+  - Context: Replaced ActivityIndicator with pulsing skeleton group cards
+  - Impact: Better loading experience, less jarring
   - File: `mobile/screens/HomeScreen.js`
   - Context: Replace ActivityIndicator with skeleton group cards
   - Impact: Better loading experience, less jarring

--- a/mobile/components/skeletons/GroupListSkeleton.js
+++ b/mobile/components/skeletons/GroupListSkeleton.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Card } from 'react-native-paper';
+import Skeleton from '../ui/Skeleton';
+
+const GroupListSkeleton = ({ count = 4 }) => {
+  return (
+    <View
+      accessible={true}
+      accessibilityRole="progressbar"
+      accessibilityLabel="Loading groups"
+      style={styles.container}
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <Card key={`group-skeleton-${index}`} style={styles.card}>
+          <Card.Title
+            title={<Skeleton width={150} height={20} />}
+            left={() => <Skeleton width={40} height={40} borderRadius={20} />}
+          />
+          <Card.Content>
+            <View style={styles.contentRow}>
+              <Skeleton width={120} height={16} />
+            </View>
+          </Card.Content>
+        </Card>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+  contentRow: {
+    marginTop: 4,
+  },
+});
+
+export default GroupListSkeleton;

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, View, StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius = 4, style }) => {
+  const theme = useTheme();
+  const animatedValue = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(animatedValue, {
+          toValue: 0.7,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+        Animated.timing(animatedValue, {
+          toValue: 0.3,
+          duration: 1000,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+  }, [animatedValue]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.skeleton,
+        {
+          width,
+          height,
+          borderRadius,
+          backgroundColor: theme.colors.surfaceVariant,
+          opacity: animatedValue,
+        },
+        style,
+      ]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  skeleton: {
+    overflow: 'hidden',
+  },
+});
+
+export default Skeleton;

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import { Alert, FlatList, RefreshControl, StyleSheet, View } from "react-native";
 import {
-  ActivityIndicator,
   Appbar,
   Avatar,
   Modal,
@@ -17,6 +16,7 @@ import * as Haptics from "expo-haptics";
 import { createGroup, getGroups, getOptimizedSettlements } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
 import { formatCurrency, getCurrencySymbol } from "../utils/currency";
+import GroupListSkeleton from "../components/skeletons/GroupListSkeleton";
 
 const HomeScreen = ({ navigation }) => {
   const { token, logout, user } = useContext(AuthContext);
@@ -257,9 +257,7 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" />
-        </View>
+        <GroupListSkeleton count={4} />
       ) : (
         <FlatList
           data={groups}


### PR DESCRIPTION
Implemented a complete skeleton loading system for the `HomeScreen` groups list in the mobile application. This replaces the generic full-screen activity indicator with an animated, structure-aware loading state that mimics the actual content layout, significantly reducing layout shift and improving perceived performance. The implementation includes a core pulsing `Skeleton` component and a composite `GroupListSkeleton` built with React Native Paper cards. Accessibility has been considered by keeping noise minimal (via container-level ARIA roles instead of element-level).

---
*PR created automatically by Jules for task [3671660779610084956](https://jules.google.com/task/3671660779610084956) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced home screen loading experience with animated skeleton placeholders that match group card layouts, reducing visual jarring and providing smoother transitions while content loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->