### PR TITLE
[jules] ux: Complete skeleton loading for HomeScreen groups

### DIFF
--- a/.Jules/changelog.md
+++ b/.Jules/changelog.md
@@ -1,5 +1,15 @@
 # Splitwiser UI/UX Changelog
 
+
+## [Unreleased]
+
+### Added
+- Created reusable `Skeleton` UI primitive in `mobile/components/ui/Skeleton.js` with pulsing animation.
+- Created `GroupListSkeleton` in `mobile/components/skeletons/GroupListSkeleton.js` using the new `Skeleton` component.
+
+### Changed
+- Replaced `ActivityIndicator` with `GroupListSkeleton` in `mobile/screens/HomeScreen.js` for a better loading experience.
+
 > All UI/UX changes made by Jules automated enhancement agent.
 
 ---

--- a/.Jules/todo.md
+++ b/.Jules/todo.md
@@ -57,7 +57,9 @@
   - Impact: Native feel, users can easily refresh data
   - Size: ~150 lines
 
-- [ ] **[ux]** Complete skeleton loading for HomeScreen groups
+- [x] **[ux]** Complete skeleton loading for HomeScreen groups
+  - Completed: 2026-04-16
+  - Files modified: `mobile/screens/HomeScreen.js`, `mobile/components/ui/Skeleton.js`, `mobile/components/skeletons/GroupListSkeleton.js`
   - File: `mobile/screens/HomeScreen.js`
   - Context: Replace ActivityIndicator with skeleton group cards
   - Impact: Better loading experience, less jarring

--- a/mobile/components/skeletons/GroupListSkeleton.js
+++ b/mobile/components/skeletons/GroupListSkeleton.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Card } from 'react-native-paper';
+import Skeleton from '../ui/Skeleton';
+
+const GroupListSkeletonItem = () => (
+  <Card style={styles.card}>
+    <Card.Title
+      title={<Skeleton width={120} height={20} />}
+      left={(props) => (
+        <View {...props}>
+          <Skeleton width={40} height={40} borderRadius={20} />
+        </View>
+      )}
+    />
+    <Card.Content>
+      <Skeleton width={200} height={16} style={{ marginTop: 4 }} />
+    </Card.Content>
+  </Card>
+);
+
+const GroupListSkeleton = () => {
+  return (
+    <View style={styles.container}>
+      {[1, 2, 3, 4, 5].map((key) => (
+        <GroupListSkeletonItem key={key} />
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  card: {
+    marginBottom: 16,
+  },
+});
+
+export default GroupListSkeleton;

--- a/mobile/components/ui/Skeleton.js
+++ b/mobile/components/ui/Skeleton.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+const Skeleton = ({ width, height, borderRadius = 4, style }) => {
+  const theme = useTheme();
+  const opacity = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 0.7,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.3,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    loop.start();
+
+    return () => {
+      loop.stop();
+    };
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.skeleton,
+        {
+          width,
+          height,
+          borderRadius,
+          backgroundColor: theme.colors.surfaceVariant,
+          opacity,
+        },
+        style,
+      ]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  skeleton: {
+    overflow: 'hidden',
+  },
+});
+
+export default Skeleton;

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -17,6 +17,7 @@ import * as Haptics from "expo-haptics";
 import { createGroup, getGroups, getOptimizedSettlements } from "../api/groups";
 import { AuthContext } from "../context/AuthContext";
 import { formatCurrency, getCurrencySymbol } from "../utils/currency";
+import GroupListSkeleton from "../components/skeletons/GroupListSkeleton";
 
 const HomeScreen = ({ navigation }) => {
   const { token, logout, user } = useContext(AuthContext);
@@ -257,9 +258,7 @@ const HomeScreen = ({ navigation }) => {
       </Appbar.Header>
 
       {isLoading ? (
-        <View style={styles.loaderContainer}>
-          <ActivityIndicator size="large" />
-        </View>
+        <GroupListSkeleton />
       ) : (
         <FlatList
           data={groups}


### PR DESCRIPTION
- Created `mobile/components/ui/Skeleton.js` to serve as a reusable skeleton loading component.
- Created `mobile/components/skeletons/GroupListSkeleton.js` to represent a layout matching the `HapticCard` on the HomeScreen.
- Replaced `ActivityIndicator` in `HomeScreen.js` with `GroupListSkeleton`.
- Ensured proper use of `react-native-paper` theming (`theme.colors.surfaceVariant`) and lifecycle hooks (`loop.stop()` cleanup).
- Updated documentation.

---
*PR created automatically by Jules for task [4050041467099439475](https://jules.google.com/task/4050041467099439475) started by @Devasy23*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved loading UI on HomeScreen with animated skeleton placeholder cards that display while groups load. The smooth pulsing animation provides better visual feedback compared to the previous spinner-based loader, enhancing the overall user experience.

* **Documentation**
  * Updated project tracking and changelog to document the completion of skeleton loading improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->