### PR TITLE
docs: add env copy example in backend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,4 +244,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 **Made with ❤️ for splitting expenses the smart way!**
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions
+- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.

--- a/README.md
+++ b/README.md
@@ -244,7 +244,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 **Made with ❤️ for splitting expenses the smart way!**
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
-
-## Contributors
-- Yashika Panwar - CSE AIML, DCE Gurugram | GSSoC Aspirant
+- [Discord community](https://chat.expo.dev): Chat with Expo users and ask question 

--- a/README.md
+++ b/README.md
@@ -244,4 +244,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 **Made with ❤️ for splitting expenses the smart way!**
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask question 
+- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions

--- a/README.md
+++ b/README.md
@@ -245,3 +245,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Contributors
+- Yashika Panwar - CSE AIML, DCE Gurugram | GSSoC Aspirant

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,7 +10,9 @@ This is the FastAPI backend for the Splitwiser expense tracking application.
    ```
 
 2. **Environment Configuration:**
-   - Copy `.env.example` to `.env`
+   - Copy `.env.example` to `.env`:
+   ```bash
+   cp .env.example .env
    - Update the environment variables:
      - `MONGODB_URL`: Your MongoDB connection string
      - `SECRET_KEY`: A secure secret key for JWT tokens

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,7 @@ This is the FastAPI backend for the Splitwiser expense tracking application.
    - Copy `.env.example` to `.env`:
    ```bash
    cp .env.example .env
+   ```
    - Update the environment variables:
      - `MONGODB_URL`: Your MongoDB connection string
      - `SECRET_KEY`: A secure secret key for JWT tokens


### PR DESCRIPTION
Added bash example for copying .env.example to .env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a ready-to-run command for creating the environment configuration file from the provided example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->